### PR TITLE
fix issue 103: https://github.com/lisong/code-push-server/issues/103

### DIFF
--- a/routes/apps.js
+++ b/routes/apps.js
@@ -318,7 +318,7 @@ router.post('/:appName/deployments/:deploymentName/release',
     });
   })
   .then((data) => {
-    res.send("");
+    res.send('{"msg": "succeed"}');
   })
   .catch((e) => {
     if (e instanceof AppError.AppError) {


### PR DESCRIPTION
according https://github.com/Microsoft/code-push/blob/master/sdk/script/management-sdk.ts#L337
```
   if (expectResponseBody && !body) {
        reject({ message: "Could not parse response: " + res.text, statusCode: res.status });
   }
```

if code-push successfully release a new packages with sending `''` as response text,  we always encounter this error `'Could not parse response:'`. 

Instead we should send a JSON string as response text, like `'{"msg": "succeed"}'`.