### PR TITLE
升级formidable

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "debug": "^2.6.8",
     "express": "^4.14.0",
     "extract-zip": "^1.6.0",
-    "formidable": "^1.0.17",
+    "formidable": "^1.2.1",
     "fs-extra": "^3.0.1",
     "helmet": "^3.1.0",
     "i18n": "^0.8.3",


### PR DESCRIPTION
升级formidable至1.2.1(最低1.1.1), 增加maxFilesSize选项, 避免bundle资源过大出现的upload error