### PR TITLE
增加maxFilesSize属性

### DIFF
--- a/core/services/package-manager.js
+++ b/core/services/package-manager.js
@@ -31,6 +31,7 @@ proto.parseReqFile = function (req) {
   log.debug('parseReqFile');
   return new Promise((resolve, reject) => {
     var form = new formidable.IncomingForm();
+    form.maxFilesSize = 200 * 1024 * 1024;
     form.parse(req, (err, fields, files) => {
       if (err) {
         log.debug('parseReqFile:', err);

--- a/core/services/package-manager.js
+++ b/core/services/package-manager.js
@@ -31,7 +31,7 @@ proto.parseReqFile = function (req) {
   log.debug('parseReqFile');
   return new Promise((resolve, reject) => {
     var form = new formidable.IncomingForm();
-    form.maxFilesSize = 200 * 1024 * 1024;
+    form.maxFieldsSize = 200 * 1024 * 1024;
     form.parse(req, (err, fields, files) => {
       if (err) {
         log.debug('parseReqFile:', err);


### PR DESCRIPTION
增加maxFilesSize属性, 避免bundle资源过大, 导致的upload error