### PR TITLE
fix ios Code Signing bug

### DIFF
--- a/core/utils/security.js
+++ b/core/utils/security.js
@@ -160,6 +160,16 @@ security.calcAllFileSha256 = function (directoryPath) {
           log.debug(`calcAllFileSha256 empty files in directoryPath:`, directoryPath);
           reject(new AppError.AppError("empty files"));
         }else {
+          //筛选掉不用hash计算的文件
+          files = files.filter((file) =>{
+            if ((file.indexOf(".codepushrelease") >= 0)||
+              (file.indexOf(".DS_Store") >= 0)||
+              (file.indexOf("__MACOSX/") >= 0)) {
+              return false;
+            }else{
+              return true;
+            }
+          });
           security.sha256AllFiles(files)
           .then((results) => {
             var data = {};


### PR DESCRIPTION
when use Code Signing. iOSSDK has ignore the follow files for compute hash:
```
4. NSString * const IgnoreMacOSX= @"__MACOSX/";
5. NSString * const IgnoreDSStore = @".DS_Store";
6. NSString * const IgnoreCodePushMetadata = @".codepushrelease";
```
so, we need igore file in the serverSDK.

[relative bugs](https://github.com/lisong/code-push-server/issues/174)