### PR TITLE
修改由于 code-push 的 release 命令发布热更新可能导致hash值不同bug

### DIFF
--- a/core/utils/security.js
+++ b/core/utils/security.js
@@ -69,7 +69,7 @@ security.packageHashSync = function (jsonData) {
   log.debug('packageHashSync manifestData:', manifestData);
   var manifestString = JSON.stringify(manifestData.sort());
   manifestString = _.replace(manifestString, /\\\//g, '/');
-  log.debug('packageHashSync manifestString:', manifestData);
+  log.debug('packageHashSync manifestString:', manifestString);
   return security.stringSha256Sync(manifestString);
 }
 
@@ -202,6 +202,10 @@ security.calcAllFileSha256 = function (directoryPath) {
             var data = {};
             _.forIn(results, (value, key) => {
               var relativePath = path.relative(directoryPath, key);
+              var matchresult = relativePath.match(/(\/|\\).*/);
+              if (matchresult) {
+                  relativePath = path.join('CodePush', matchresult[0]);
+              }
               relativePath = slash(relativePath);
               data[relativePath] = value;
             });


### PR DESCRIPTION
### 存在的问题

通过code-push的 release 命令直接上传包到服务器时, 生成的hash值可能会与生成iOS应用包时,包含进入的RN包的hash值不一致。

产生问题的具体步骤如下：
1. 我先手动打了一个bundle包，命令如下：
```
react-native bundle --entry-file index.ios.js --platform ios --dev false --bundle-output "/Users/jeff.li/Desktop/bundle/main.jsbundle" --assets-dest "/Users/jeff.li/Desktop/bundle"
```

此时，我电脑的桌面上有一个bundle文件夹，里面包含main.jsbundle和asserts文件

2. 使用上一步骤生成的RN包传到热更新服务器，使用如下命令：
```
code-push release "myapp" "/Users/jeff.li/Desktop/bundle" "3.7.3" --d "Staging" --des "更新bundle啦" --m "true"
```

3. 运行iOS应用，通过抓包发现，检查更新时，即使是同样的代码，hash是不一样的。这就导致了应用必须全量再下载一次RN包。（也就没有达到使用原则第五条所说的：每次向App Store提交新的版本时，也应该基于该提交版本同时向code-push-server发布一个初始版本。(因为后面每次向code-push-server发布版本时，code-puse-server都会和初始版本比较，生成补丁版本)）

### 原因分析
因为在iOS应用中，CodePush这个框架在计算打包进入应用的RN包的hash值时，在解析路径时，固定地使用了这样的相对路径来计算hash值：
CodePush/main.jsbundle:hash值
CodePush/assets/图片路径:图片hash值
![image](https://user-images.githubusercontent.com/17615716/66710680-070f9700-edb0-11e9-860e-9974b523d9ff.png)
![image](https://user-images.githubusercontent.com/17615716/66710684-17c00d00-edb0-11e9-8313-c7df2c79235c.png)


最终要计算hash值的字符串形如：
![image](https://user-images.githubusercontent.com/17615716/66710686-21e20b80-edb0-11e9-8d95-03b016cffdf1.png)




而在code-push-server这边的计算方式与CodePush的计算方式是一样的，不过存在一点差异：
就是在解压包之后，就按着这个包的内容来进行进行hash运算，最终就导致了最终要计算的hash值字符串不一致了，如下图所示：
![image](https://user-images.githubusercontent.com/17615716/66710703-5bb31200-edb0-11e9-86ba-9826a9f6688f.png)



因为相对路径值不同，导致最终计算得到的hash值不同

### Pull Request

我的修改方案是 **core/utils/security.js**文件中做如下修改：
![image](https://user-images.githubusercontent.com/17615716/66710727-dc720e00-edb0-11e9-9dfd-de75e1fc2d2c.png)



确保相对路径的开头是CodePush