### PR TITLE
修复code-push deployment history查询结果中的isDisabled一直是false的问题

### DIFF
--- a/core/services/deployments.js
+++ b/core/services/deployments.js
@@ -138,7 +138,7 @@ proto.formatPackage = function(packageVersion) {
   }
   return {
     description: _.get(packageVersion, "packageInfo.description"),
-    isDisabled: false,
+    isDisabled: _.get(packageVersion, "packageInfo.is_disabled") == 1 ? true : false,
     isMandatory: _.get(packageVersion, "packageInfo.is_mandatory") == 1 ? true : false,
     rollout: 100,
     appVersion: _.get(packageVersion, "deploymentsVersions.app_version"),


### PR DESCRIPTION
修复code-push deployment history查询结果中的isDisabled一直是false的问题（即使使用code-push patch --disabled true 设置了isDisabled为true）