### PR TITLE
fix: modify the body params of deploy report

### DIFF
--- a/core/services/client-manager.js
+++ b/core/services/client-manager.js
@@ -266,8 +266,8 @@ proto.reportStatusDeploy = function (deploymentKey, label, clientUniqueId, other
       status = constConfig.DEPLOYMENT_FAILED;
     }
     var packageId = packages.id;
-    var previous_deployment_key = _.get(others, 'previousDeploymentKey');
-    var previous_label = _.get(others, 'previousLabelOrAppVersion');
+    var previous_deployment_key = _.get(others, 'previous_deployment_key');
+    var previous_label = _.get(others, 'previous_label_or_app_version');
     if (status > 0) {
       return Promise.all([
         models.LogReportDeploy.create({


### PR DESCRIPTION
BUG: 
deploy report use the params:

`previousDeploymentKey `
`previousLabelOrAppVersion `

different from the 

https://github.com/microsoft/code-push/blob/6f9c5ea519e26a65d9bf9530ecc6b825cd9e53d4/src/script/acquisition-sdk.ts#L182-L188

FIX:

`previous_deployment_key `
`previous_label_or_app_version `