### PR TITLE
fix: code-push 3.0.1 compatibility issue

### DIFF
--- a/routes/indexV1.js
+++ b/routes/indexV1.js
@@ -37,7 +37,9 @@ router.get('/update_check', (req, res, next) => {
         description : rs.description,
         is_available : rs.isAvailable,
         is_disabled : rs.isDisabled,
-        target_binary_range: rs.targetBinaryRange,
+        // Note: need to use appVersion here to get it compatible with client side change...
+        // https://github.com/microsoft/code-push/commit/7d2ffff395cc54db98aefba7c67889f509e8c249#diff-a937c637a47cbd31cbb52c89bef7d197R138
+        target_binary_range: rs.appVersion,
         label: rs.label,
         package_hash: rs.packageHash,
         package_size: rs.packageSize,


### PR DESCRIPTION
Somehow it's updated to use update_check response `target_binary_range` for previous `appVersion` while the rest client side code seems no updates regarding this. Therefore we should do the same at the server side to get it compatible with 3.0.1+ version. The real `target_binary_range` like `^9.0.0` just won't work with latest code push client (react-native-code-push@6.2.1)

----
https://github.com/microsoft/code-push/commit/7d2ffff395cc54db98aefba7c67889f509e8c249#diff-a937c637a47cbd31cbb52c89bef7d197R138